### PR TITLE
save and restore the pr-preview folder in build-docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docs
+          keep_files: true
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/docs/pr-preview/pr-71/CNAME
+++ b/docs/pr-preview/pr-71/CNAME
@@ -1,1 +1,0 @@
-fsml.org

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "serve": "docusaurus serve --dir=../docs --port=5555",
     "save-previews": "git checkout origin/gh-pages -- ../pr-preview  && git restore --staged ../pr-preview/*",
     "restore-previews": "mv ../pr-preview ../docs/pr-preview",
-    "build-docs-saving-previews": "yarn save-previews && yarn build-pr-docs && yarn restore-previews",
+    "build-docs-saving-previews": "yarn save-previews && yarn build-docs && yarn restore-previews",
     "build-docs": "yarn clear && docusaurus build --out-dir ../docs",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"

--- a/website/package.json
+++ b/website/package.json
@@ -10,9 +10,10 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --dir=../docs --port=5555",
-    "save-previews": "git branch && git checkout origin/gh-pages -- ../pr-preview  && git restore --staged ../pr-preview/*",
+    "save-previews": "git checkout origin/gh-pages -- ../pr-preview  && git restore --staged ../pr-preview/*",
     "restore-previews": "mv ../pr-preview ../docs/pr-preview",
-    "build-docs": "yarn save-previews && yarn clear && docusaurus build --out-dir ../docs && yarn restore-previews",
+    "build-docs-saving-previews": "yarn save-previews && yarn build-pr-docs && yarn restore-previews",
+    "build-docs": "yarn clear && docusaurus build --out-dir ../docs",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,8 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --dir=../docs --port=5555",
-    "save-previews": "[ -d '../docs/pr-preview' ] && mv ../docs/pr-preview ../tmp-preview",
-    "restore-previews": "[ -d '../tmp-preview' ] && mv ../tmp-preview ../docs/pr-preview",
+    "save-previews": "git checkout origin/gh-pages -- ../pr-preview  && git restore --staged ../pr-preview/*",
+    "restore-previews": "mv ../pr-preview ../docs/pr-preview",
     "build-docs": "yarn save-previews && yarn clear && docusaurus build --out-dir ../docs && yarn restore-previews",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve --dir=../docs --port=5555",
-    "save-previews": "git checkout origin/gh-pages -- ../pr-preview  && git restore --staged ../pr-preview/*",
+    "save-previews": "git branch && git checkout origin/gh-pages -- ../pr-preview  && git restore --staged ../pr-preview/*",
     "restore-previews": "mv ../pr-preview ../docs/pr-preview",
     "build-docs": "yarn save-previews && yarn clear && docusaurus build --out-dir ../docs && yarn restore-previews",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
add keep_files flag to publish workflow to avoid deleting pr-preview folder
Unfortunately there isn't a specific flag to just apply that to the pr-preview folder so pages might get left behind